### PR TITLE
Minor changes to better prepare for Null Safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.3.0
+
+* The `SyncHttpClientResponse.contentLength` getter will return `-1` instead of
+  `null` if content length not specified.
+
+* Implement `chunkedTransferEncoding` getters.
+
 ## v0.2.0
 
 * Preparation for [HttpHeaders change]. Update signature of `add()`

--- a/lib/src/sync_http.dart
+++ b/lib/src/sync_http.dart
@@ -263,7 +263,10 @@ class _SyncHttpClientRequestHeaders implements HttpHeaders {
   }
 
   @override
-  bool get chunkedTransferEncoding => null;
+  bool get chunkedTransferEncoding {
+    return value(HttpHeaders.transferEncodingHeader)?.toLowerCase() ==
+        'chunked';
+  }
 
   @override
   void set chunkedTransferEncoding(bool _chunkedTransferEncoding) {
@@ -454,7 +457,10 @@ class _SyncHttpClientResponseHeaders implements HttpHeaders {
   }
 
   @override
-  bool get chunkedTransferEncoding => null;
+  bool get chunkedTransferEncoding {
+    return value(HttpHeaders.transferEncodingHeader)?.toLowerCase() ==
+        'chunked';
+  }
 
   @override
   void set chunkedTransferEncoding(bool _chunkedTransferEncoding) {

--- a/lib/src/sync_http.dart
+++ b/lib/src/sync_http.dart
@@ -32,8 +32,8 @@ abstract class SyncHttpClient {
 class SyncHttpClientRequest {
   static const String _protocolVersion = '1.1';
 
-  /// The length of the request body. Is set to null when no body exists.
-  int get contentLength => hasBody ? _body.length : null;
+  /// The length of the request body. Is set to `-1` when no body exists.
+  int get contentLength => hasBody ? _body.length : -1;
 
   HttpHeaders _headers;
 
@@ -471,9 +471,12 @@ class _SyncHttpClientResponseHeaders implements HttpHeaders {
   int get contentLength {
     String val = value(HttpHeaders.contentLengthHeader);
     if (val != null) {
-      return int.tryParse(val);
+      var parsed = int.tryParse(val);
+      if (parsed != null) {
+        return parsed;
+      }
     }
-    return null;
+    return -1;
   }
 
   @override


### PR DESCRIPTION
I've looked at the output from the migration tool and found a few places where it generates suboptimal code due to the nullability changes in the `HttpHeaders`. So this PR tries to better follow them and should make switching to Null Safety easier.

Let me know what you think or if you have any concerns! :)