### PR TITLE
prep for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.1
+
+* Switch to using `package:lints/recommended.yaml`
+* Update the usage guidance in the readme.
+
 ## v0.3.0
 
 * Stable version for null safety.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-[![Build Status](https://travis-ci.org/dart-lang/sync_http.svg?branch=master)](https://travis-ci.org/dart-lang/sync_http/)
+[![Dart CI](https://github.com/google/sync_http.dart/actions/workflows/test-package.yml/badge.svg)](https://github.com/google/sync_http.dart/actions/workflows/test-package.yml)
 [![pub package](https://img.shields.io/pub/v/sync_http.svg)](https://pub.dev/packages/sync_http)
+[![package publisher](https://img.shields.io/pub/publisher/sync_http.svg)](https://pub.dev/packages/sync_http/publisher)
 
-A simple Dart HTTP client implemented using RawSynchronousSockets to allow for
+A Dart HTTP client implemented using RawSynchronousSockets to allow for
 synchronous HTTP requests.
 
-**Warning**: This library should probably only be used to connect to HTTP 
-servers that are hosted on 'localhost'. The operations in this library will
-block the calling thread to wait for a response from the HTTP server. The thread
-can process no other events while waiting for the server to respond. As such,
-this synchronous HTTP client library is not suitable for applications that
-require high performance. Instead, such applications should use libraries built
-on asynchronous I/O, including
+## Using this package
+
+**Note**: this package is only intended for very specialized use cases. For
+general HTTP usage, please see instead
+[package:http](https://pub.dev/packages/http).
+
+This library should probably only be used to connect to HTTP servers that are
+hosted on 'localhost'. The operations in this library will block the calling
+thread to wait for a response from the HTTP server. The thread can process no
+other events while waiting for the server to respond. As such, this synchronous
+HTTP client library is not suitable for applications that require high
+performance. Instead, such applications should use libraries built on
+asynchronous I/O, including
 [dart:io](https://api.dart.dev/stable/dart-io/dart-io-library.html)
 and [package:http](https://pub.dev/packages/http), for the best 
 performance.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,48 +1,5 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   strong-mode:
     implicit-casts: false
-
-linter:
-  rules:
-    - avoid_empty_else
-    - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
-    - avoid_unused_constructor_parameters
-    - await_only_futures
-    - camel_case_types
-    - cancel_subscriptions
-    - constant_identifier_names
-    - control_flow_in_finally
-    - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
-    - empty_statements
-    - hash_and_equals
-    - implementation_imports
-    - iterable_contains_unrelated_type
-    - library_names
-    - library_prefixes
-    - list_remove_unrelated_type
-    - non_constant_identifier_names
-    - overridden_fields
-    - package_api_docs
-    - package_names
-    - package_prefixed_library_names
-    - prefer_equal_for_default_values
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_generic_function_type_aliases
-    - prefer_is_not_empty
-    - prefer_relative_imports
-    - slash_for_doc_comments
-    - test_types_in_equals
-    - throw_in_finally
-    - type_init_formals
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_new
-    - unnecessary_parenthesis
-    - unrelated_type_equality_checks
-    - valid_regexps

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,17 @@ include: package:lints/recommended.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
+
+linter:
+  rules:
+    - always_declare_return_types
+    - avoid_dynamic_calls
+    - avoid_unused_constructor_parameters
+    - cancel_subscriptions
+    - directives_ordering
+    - omit_local_variable_types
+    - package_api_docs
+    - prefer_single_quotes
+    - test_types_in_equals
+    - throw_in_finally
+    - unawaited_futures

--- a/lib/src/sync_http.dart
+++ b/lib/src/sync_http.dart
@@ -56,9 +56,8 @@ class SyncHttpClientRequest {
   /// The synchronous socket used to initiate the HTTP request.
   final RawSynchronousSocket _socket;
 
-  SyncHttpClientRequest._(this.method, Uri uri, bool body)
-      : uri = uri,
-        _body = body ? BytesBuilder() : null,
+  SyncHttpClientRequest._(this.method, this.uri, bool body)
+      : _body = body ? BytesBuilder() : null,
         _socket = RawSynchronousSocket.connectSync(uri.host, uri.port);
 
   /// Write content into the body of the HTTP request.
@@ -92,9 +91,9 @@ class SyncHttpClientRequest {
     var buffer = StringBuffer();
     buffer.write('$method ${uri.path}$queryString HTTP/$_protocolVersion\r\n');
     headers.forEach((name, values) {
-      values.forEach((value) {
+      for (var value in values) {
         buffer.write('$name: $value\r\n');
-      });
+      }
     });
     buffer.write('\r\n');
     if (hasBody) {
@@ -241,12 +240,12 @@ class _SyncHttpClientRequestHeaders implements HttpHeaders {
   /// Iterates over all header key-value pairs and applies [f].
   @override
   void forEach(void Function(String name, List<String> values) f) {
-    var forEachFunc = (String name) {
+    void forEachFunc(String name) {
       var values = this[name];
       if (values != null && values.isNotEmpty) {
         f(name, values);
       }
-    };
+    }
 
     [
       HttpHeaders.acceptCharsetHeader,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sync_http
-version: 0.3.1-dev
+version: 0.3.1
 description: Synchronous HTTP client for Dart.
 repository: https://github.com/google/sync_http.dart
 
@@ -7,5 +7,5 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety.0
-  test: ^1.16.0-nullsafety.8
+  lints: ^1.0.0
+  test: ^1.16.0

--- a/test/http_basic_test.dart
+++ b/test/http_basic_test.dart
@@ -97,6 +97,8 @@ void startTestServer(SendPort replyTo) {
   replyTo.send(server.dispatchSendPort);
 }
 
+typedef _RequestHandler = void Function(HttpRequest request);
+
 class TestServer {
   // Echo the request content back to the response.
   void _echoHandler(HttpRequest request) {
@@ -212,7 +214,7 @@ class TestServer {
 
   late HttpServer _server; // HTTP server instance.
   late ReceivePort _dispatchPort;
-  late Map _requestHandlers;
+  late Map<String, _RequestHandler> _requestHandlers;
 }
 
 Future testStartStop() async {


### PR DESCRIPTION
Prep for publishing:

- switch to using package:lints
- update the readme markdown badges
- adjust the usage guidance in the readme a bit - highlight that people should generally be using package:http

Publishing will let us capture the above changes as well as a previous change to the pubspec repository field.